### PR TITLE
Fix floating-point lt/le mix-up

### DIFF
--- a/angr/engines/vex/claripy/irop.py
+++ b/angr/engines/vex/claripy/irop.py
@@ -982,10 +982,10 @@ class SimIROp:
         return self._fp_vector_comparison(claripy.fpEQ, a0, a1)
 
     def _op_fgeneric_CmpLE(self, a0, a1):
-        return self._fp_vector_comparison(claripy.fpLT, a0, a1)
+        return self._fp_vector_comparison(claripy.fpLEQ, a0, a1)
 
     def _op_fgeneric_CmpLT(self, a0, a1):
-        return self._fp_vector_comparison(claripy.fpLEQ, a0, a1)
+        return self._fp_vector_comparison(claripy.fpLT, a0, a1)
 
     def _auto_vectorize(self, f, args, rm=None, rm_passed=False):
         if rm is not None:

--- a/tests/engines/vex/test_vex.py
+++ b/tests/engines/vex/test_vex.py
@@ -577,6 +577,44 @@ class TestVex(unittest.TestCase):
         solver.add(sm.one_deadended.regs.rax != target_func)
         assert not solver.satisfiable()
 
+    def test_cmpltsd(self):
+        p = load_shellcode(bytes.fromhex("f20fc2c101c3"), arch="amd64")
+        # 0000000000000000 F20FC2C101                      CMPLTSD XMM0,XMM1
+        # 0000000000000005 C3                              RET
+        x = claripy.BVS("x", 64)
+        x_fp = claripy.fpToFP(x, claripy.FSORT_DOUBLE)
+        y = claripy.BVS("y", 64)
+        y_fp = claripy.fpToFP(y, claripy.FSORT_DOUBLE)
+        s = p.factory.call_state(0)
+        s.regs.xmm0lq = x
+        s.regs.xmm1lq = y
+        sm = p.factory.simulation_manager(s)
+        sm.run()
+
+        target_func = claripy.If(x_fp < y_fp, claripy.BVV(-1, 64), claripy.BVV(0, 64))
+        solver = claripy.Solver()
+        solver.add(sm.one_deadended.regs.xmm0lq != target_func)
+        assert not solver.satisfiable()
+
+    def test_cmplesd(self):
+        p = load_shellcode(bytes.fromhex("f20fc2c102c3"), arch="amd64")
+        # 0000000000000000 F20FC2C102                      CMPLESD XMM0,XMM1
+        # 0000000000000005 C3                              RET
+        x = claripy.BVS("x", 64)
+        x_fp = claripy.fpToFP(x, claripy.FSORT_DOUBLE)
+        y = claripy.BVS("y", 64)
+        y_fp = claripy.fpToFP(y, claripy.FSORT_DOUBLE)
+        s = p.factory.call_state(0)
+        s.regs.xmm0lq = x
+        s.regs.xmm1lq = y
+        sm = p.factory.simulation_manager(s)
+        sm.run()
+
+        target_func = claripy.If(x_fp <= y_fp, claripy.BVV(-1, 64), claripy.BVV(0, 64))
+        solver = claripy.Solver()
+        solver.add(sm.one_deadended.regs.xmm0lq != target_func)
+        assert not solver.satisfiable()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
SimIROp has floating-point less-than and less-than-or-equal the wrong way around.